### PR TITLE
DxLibの使用文字コードをShift-JISからUTF-8へ変更

### DIFF
--- a/Novel_Engine.vcxproj
+++ b/Novel_Engine.vcxproj
@@ -32,6 +32,7 @@
     <ClCompile Include="source\Menu.cpp" />
     <ClCompile Include="source\Place.cpp" />
     <ClCompile Include="source\Title.cpp" />
+    <ClCompile Include="source\Utilities.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="source\BackImage.h" />
@@ -46,6 +47,7 @@
     <ClInclude Include="source\Menu.h" />
     <ClInclude Include="source\Place.h" />
     <ClInclude Include="source\Title.h" />
+    <ClInclude Include="source\Utilities.h" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>16.0</VCProjectVersion>

--- a/Novel_Engine.vcxproj.filters
+++ b/Novel_Engine.vcxproj.filters
@@ -54,6 +54,9 @@
     <ClCompile Include="source\Image.cpp">
       <Filter>ソース ファイル</Filter>
     </ClCompile>
+    <ClCompile Include="source\Utilities.cpp">
+      <Filter>ソース ファイル</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="source\BackImage.h">
@@ -90,6 +93,9 @@
       <Filter>ヘッダー ファイル</Filter>
     </ClInclude>
     <ClInclude Include="source\Image.h">
+      <Filter>ヘッダー ファイル</Filter>
+    </ClInclude>
+    <ClInclude Include="source\Utilities.h">
       <Filter>ヘッダー ファイル</Filter>
     </ClInclude>
   </ItemGroup>

--- a/source/BGM.h
+++ b/source/BGM.h
@@ -1,11 +1,9 @@
 #pragma once
 #include <string>
-//#include <string_view>
 #include "DxLib.h"
 #include "Global.h"
 
 using std::string;
-//using std::string_view;
 
 namespace Game {
 	enum class BGM_effct

--- a/source/Choice.h
+++ b/source/Choice.h
@@ -1,6 +1,5 @@
 #pragma once
 #include <string>
-//#include <string_view>
 #include <vector>
 #include "Global.h"
 #include "Dialog.h"

--- a/source/Dialog.cpp
+++ b/source/Dialog.cpp
@@ -1,21 +1,6 @@
 #include "Dialog.h"
 
 namespace Game {
-	/// <summary>
-	/// 文字数を数える
-	/// </summary>
-	/// <param name="str">文字列</param>
-	/// <returns>文字数(size_t)</returns>
-	static size_t strcount_sjis(string_view str);
-
-	/// <summary>
-	/// 先頭から、指定した文字数を抽出
-	/// </summary>
-	/// <param name="str">文字列</param>
-	/// <param name="nCount">文字数</param>
-	/// <returns>抽出した文字列</returns>
-	static string strextract_sjis(string_view str, size_t nCount);
-
 	int Dialog::gh_box = 0;
 
 	void Dialog::Set(string_view speaker, string_view content) {
@@ -25,7 +10,6 @@ namespace Game {
 		status = 0;
 		strContDisp = "";
 		index_strCont = 0;
-		//nWordContnet = strcount_sjis(strContent);
 		nWordContnet = strcount_utf8(strContent.c_str());
 		fcounter = 0;
 	}
@@ -46,7 +30,6 @@ namespace Game {
 				index_strCont += 2;
 			}
 			if (index_strCont <= nWordContnet) {
-				//strContDisp = strextract_sjis(strContent, index_strCont);
 				strContDisp = strextract_utf8(strContent.c_str(), index_strCont);
 				fcounter++;
 			}
@@ -176,88 +159,5 @@ namespace Game {
 		}
 
 		return status;
-	}
-
-	size_t strcount_sjis(string_view str) {
-		size_t zStrCount = 0;
-		size_t zStrLen = str.size();
-		const char* lpStr = str.data();
-
-		for (size_t i = 0; i < zStrLen; ++i) {
-			// 2バイト文字の検出
-			if (((static_cast<unsigned char>(lpStr[i]) >= 0x81 && static_cast<unsigned char>(lpStr[i]) <= 0x9F)
-				|| (static_cast<unsigned char>(lpStr[i]) >= 0xE0 && static_cast<unsigned char>(lpStr[i]) <= 0xFC))
-				&& i + 1 < zStrLen) {
-				zStrCount++;
-				i++;
-			}
-			// 描画指定子を除外
-			else if (lpStr[i] == '\\' && i + 3 < zStrLen && lpStr[i + 3] == '\\') {
-				if (lpStr[i + 1] == 'c' || lpStr[i + 1] == 's') {
-					if (lpStr[i + 2] >= 0x30 && lpStr[i + 2] <= 0x39) {
-						i += 3;
-						continue;
-					}
-				}
-			}
-			else if (lpStr[i] == '\n') {
-				continue;
-			}
-			// 1バイト文字の検出
-			else if ((lpStr[i] >= ' ' && lpStr[i] <= '~') ||
-				(static_cast<unsigned char>(lpStr[i]) >= 0xA1 && static_cast<unsigned char>(lpStr[i]) <= 0xDF)) {
-				zStrCount++;
-			}
-		}
-
-		return zStrCount;
-	}
-
-	string strextract_sjis(string_view str, size_t nCount) {
-		size_t zStrCount = 0;
-		size_t zStrLen = str.size();
-		const char* lpStr = str.data();
-		string strRes = "";
-
-		for (size_t i = 0; i < zStrLen; ++i) {
-			if (zStrCount > nCount) {
-				break;			// 抽出する文字数を超えていたら、終了
-			}
-
-			// 2バイト文字の検出
-			if (((static_cast<unsigned char>(lpStr[i]) >= 0x81 && static_cast<unsigned char>(lpStr[i]) <= 0x9F)
-				|| (static_cast<unsigned char>(lpStr[i]) >= 0xE0 && static_cast<unsigned char>(lpStr[i]) <= 0xFC))
-				&& i + 1 < zStrLen) {
-				strRes += lpStr[i];
-				strRes += lpStr[i + 1];
-				zStrCount++;
-				i++;
-			}
-			// 描画指定子は何もせずに格納
-			else if (lpStr[i] == '\\' && i + 3 < zStrLen && lpStr[i + 3] == '\\') {
-				if (lpStr[i + 1] == 'c' || lpStr[i + 1] == 's') {
-					if (lpStr[i + 2] >= 0x30 && lpStr[i + 2] <= 0x39) {
-						strRes += lpStr[i];
-						strRes += lpStr[i + 1];
-						strRes += lpStr[i + 2];
-						strRes += lpStr[i + 3];
-						i += 3;
-						continue;
-					}
-				}
-			}
-			else if (lpStr[i] == '\n') {
-				strRes += lpStr[i];
-				continue;
-			}
-			// 1バイト文字の検出
-			else if ((lpStr[i] >= ' ' && lpStr[i] <= '~') ||
-				(static_cast<unsigned char>(lpStr[i]) >= 0xA1 && static_cast<unsigned char>(lpStr[i]) <= 0xDF)) {
-				strRes += lpStr[i];
-				zStrCount++;
-			}
-		}
-
-		return strRes;
 	}
 }

--- a/source/Dialog.cpp
+++ b/source/Dialog.cpp
@@ -25,7 +25,8 @@ namespace Game {
 		status = 0;
 		strContDisp = "";
 		index_strCont = 0;
-		nWordContnet = strcount_sjis(strContent);
+		//nWordContnet = strcount_sjis(strContent);
+		nWordContnet = strcount_utf8(strContent.c_str());
 		fcounter = 0;
 	}
 
@@ -45,7 +46,8 @@ namespace Game {
 				index_strCont += 2;
 			}
 			if (index_strCont <= nWordContnet) {
-				strContDisp = strextract_sjis(strContent, index_strCont);
+				//strContDisp = strextract_sjis(strContent, index_strCont);
+				strContDisp = strextract_utf8(strContent.c_str(), index_strCont);
 				fcounter++;
 			}
 			else {

--- a/source/Dialog.h
+++ b/source/Dialog.h
@@ -2,6 +2,7 @@
 #include <string>
 #include <string_view>
 #include "Global.h"
+#include "Utilities.h"
 
 using string = std::string;
 using string_view = std::string_view;

--- a/source/Main.cpp
+++ b/source/Main.cpp
@@ -12,7 +12,7 @@
 
 #include "DxLib.h"
 #include "nlohmann/json.hpp"
-#include "javacommons/strconv.h"
+//#include "javacommons/strconv.h"
 #include "Global.h"
 #include "Menu.h"
 #include "Place.h"
@@ -57,6 +57,7 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
 	ChangeWindowMode(TRUE);						// フルスクリーンにしない
 	SetGraphMode(1280, 720, 32);				// ウィンドウサイズと色ビット数の指定
 	SetWindowSizeExtendRate(1.0);				// 実際に表示するウィンドウサイズに変更
+	SetUseCharCodeFormat(DX_CHARCODEFORMAT_UTF8);
 
 	/* 初期化 */
 	if (DxLib_Init() == -1) {
@@ -103,15 +104,17 @@ namespace Game {
 
 	void MakeHandles() {
 		// フォント作成
-		font1 = CreateFontToHandle("游明朝", 24, -1, DX_FONTTYPE_ANTIALIASING_16X16);
-		font2 = CreateFontToHandle("游明朝", 18, -1, DX_FONTTYPE_ANTIALIASING_16X16);
-		font3 = CreateFontToHandle("游明朝", 20, -1, DX_FONTTYPE_ANTIALIASING_16X16);
-		font4 = CreateFontToHandle("游明朝", 48, -1, DX_FONTTYPE_ANTIALIASING_16X16);
-		font5 = CreateFontToHandle("游明朝", 12, -1, DX_FONTTYPE_ANTIALIASING_16X16);
-		font6 = CreateFontToHandle("游明朝", 30, -1, DX_FONTTYPE_ANTIALIASING_16X16);
+		SetFontCharCodeFormat(DX_CHARCODEFORMAT_UTF8);
+		font1 = CreateFontToHandle(reinterpret_cast<const TCHAR*>(u8"游明朝"), 24, -1, DX_FONTTYPE_ANTIALIASING_16X16, DX_CHARCODEFORMAT_UTF8);
+		font2 = CreateFontToHandle(reinterpret_cast<const TCHAR*>(u8"游明朝"), 18, -1, DX_FONTTYPE_ANTIALIASING_16X16, DX_CHARCODEFORMAT_UTF8);
+		font3 = CreateFontToHandle(reinterpret_cast<const TCHAR*>(u8"游明朝"), 20, -1, DX_FONTTYPE_ANTIALIASING_16X16, DX_CHARCODEFORMAT_UTF8);
+		font4 = CreateFontToHandle(reinterpret_cast<const TCHAR*>(u8"游明朝"), 48, -1, DX_FONTTYPE_ANTIALIASING_16X16, DX_CHARCODEFORMAT_UTF8);
+		font5 = CreateFontToHandle(reinterpret_cast<const TCHAR*>(u8"游明朝"), 12, -1, DX_FONTTYPE_ANTIALIASING_16X16, DX_CHARCODEFORMAT_UTF8);
+		font6 = CreateFontToHandle(reinterpret_cast<const TCHAR*>(u8"游明朝"), 30, -1, DX_FONTTYPE_ANTIALIASING_16X16, DX_CHARCODEFORMAT_UTF8);
 
 		// ダイアログボックス画像読み込み
-		Dialog(LoadGraph("data/picture/[自作]dialog.png"));
+		//int gh_tmp = LoadGraph(reinterpret_cast<const TCHAR*>(u8"data/picture/[自作]dialog.png"));
+		Dialog(LoadGraph(reinterpret_cast<const TCHAR*>(u8"data/picture/[自作]dialog.png")));
 	}
 
 	void DeleteHandles() {
@@ -141,31 +144,42 @@ namespace Game {
 		// ゲームタイトルの設定
 		if (js_cfg["game"].is_object()) {
 			if (js_cfg["game"]["name"].is_string()) {
-				strGameName = utf8_to_ansi(js_cfg["game"]["name"]);
+				strGameName = js_cfg["game"]["name"];
 			}
 			if (js_cfg["game"]["version"].is_string()) {
-				strGameVersion = utf8_to_ansi(js_cfg["game"]["version"]);
+				strGameVersion = js_cfg["game"]["version"];
 			}
 		}
 	}
 
 	void SetConfig() {
 		// システムSEの読み込み
+		string tmp = "";
 		if (js_cfg["se"].is_object()) {
 			if (js_cfg["se"]["cursor"].is_string()) {
-				sh_cursor = LoadSoundMem(utf8_to_ansi(js_cfg["se"]["cursor"]).c_str());
+				tmp = js_cfg["se"]["cursor"];
+				//sh_cursor = LoadSoundMem(utf8_to_ansi(js_cfg["se"]["cursor"]).c_str());
+				sh_cursor = LoadSoundMem(tmp.c_str());
 			}
 			if (js_cfg["se"]["decide"].is_string()) {
-				sh_decide = LoadSoundMem(utf8_to_ansi(js_cfg["se"]["decide"]).c_str());
+				tmp = js_cfg["se"]["decide"];
+				//sh_decide = LoadSoundMem(utf8_to_ansi(js_cfg["se"]["decide"]).c_str());
+				sh_decide = LoadSoundMem(tmp.c_str());
 			}
 			if (js_cfg["se"]["cancel"].is_string()) {
-				sh_cancel = LoadSoundMem(utf8_to_ansi(js_cfg["se"]["cancel"]).c_str());
+				tmp = js_cfg["se"]["cancel"];
+				//sh_cancel = LoadSoundMem(utf8_to_ansi(js_cfg["se"]["cancel"]).c_str());
+				sh_cancel = LoadSoundMem(tmp.c_str());
 			}
 			if (js_cfg["se"]["success"].is_string()) {
-				sh_success = LoadSoundMem(utf8_to_ansi(js_cfg["se"]["success"]).c_str());
+				tmp = js_cfg["se"]["success"];
+				//sh_success = LoadSoundMem(utf8_to_ansi(js_cfg["se"]["success"]).c_str());
+				sh_success = LoadSoundMem(tmp.c_str());
 			}
 			if (js_cfg["se"]["fail"].is_string()) {
-				sh_fail = LoadSoundMem(utf8_to_ansi(js_cfg["se"]["fail"]).c_str());
+				tmp = js_cfg["se"]["fail"];
+				//sh_fail = LoadSoundMem(utf8_to_ansi(js_cfg["se"]["fail"]).c_str());
+				sh_fail = LoadSoundMem(tmp.c_str());
 			}
 		}
 
@@ -192,12 +206,14 @@ namespace Game {
 		if (js_cfg["title"].is_object()) {
 			if (js_cfg["title"]["back"].is_array()) {
 				if (js_cfg["title"]["back"][0].is_string()) {
-					strBack = utf8_to_ansi(js_cfg["title"]["back"][0]);
+					//strBack = utf8_to_ansi(js_cfg["title"]["back"][0]);
+					strBack =js_cfg["title"]["back"][0];
 				}
 			}
 			if (js_cfg["title"]["bgm"].is_array()) {
 				if (js_cfg["title"]["bgm"][0].is_string()) {
-					strBgm = utf8_to_ansi(js_cfg["title"]["bgm"][0]);
+					//strBgm = utf8_to_ansi(js_cfg["title"]["bgm"][0]);
+					strBgm = js_cfg["title"]["bgm"][0];
 				}
 				if (js_cfg["title"]["bgm"][1].is_number()) {
 					bgmVol = js_cfg["title"]["bgm"][1];

--- a/source/Main.cpp
+++ b/source/Main.cpp
@@ -4,7 +4,6 @@
 // 配布ソースコードの一部に、以下のライブラリを含みます
 // 著作権表示等の詳細は、README.mdをご覧ください
 // ・nlohmann/json（ https://github.com/nlohmann/json ）version 3.9.1
-// ・javacommons/strconv（ https://github.com/javacommons/strconv ）v1.8.10
 // 
 // また、本ソフトは DXライブラリ（Ver3.23 https://dxlib.xsrv.jp/ ）も使用していますが
 // 配布ソースコードには含んでおりませんので、ビルドされる方は、ご自身でのダウンロードや設定等をお願いいたします
@@ -12,7 +11,6 @@
 
 #include "DxLib.h"
 #include "nlohmann/json.hpp"
-//#include "javacommons/strconv.h"
 #include "Global.h"
 #include "Menu.h"
 #include "Place.h"
@@ -48,16 +46,16 @@ namespace Game {
 
 int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _In_ LPSTR lpCmdLine, _In_ int nCmdShow) {
 	/* ウィンドウ設定 */
+	SetUseCharCodeFormat(DX_CHARCODEFORMAT_UTF8);	// DxLib関数の文字列引数に使用する文字コードの設定
 	Game::LoadConfig();
-	SetWindowText(Game::strGameName.c_str());
-	SetMainWindowClassName(Game::SOFT_NAME);	// ウィンドウクラス名を登録
-	SetAlwaysRunFlag(TRUE);						// 非アクティブ時も実行
+	SetMainWindowText(Game::strGameName.c_str());	// タイトルテキストの設定
+	SetMainWindowClassName(Game::SOFT_NAME);		// ウィンドウクラス名を登録
+	SetAlwaysRunFlag(TRUE);							// 非アクティブ時も実行
 	//SetWindowIconID(1);							// アイコン（.icoファイルとicon.rcが必要。引数はicon.rcで設定した任意のアイコンID）
-	SetOutApplicationLogValidFlag(FALSE);		// ログを出力しない
-	ChangeWindowMode(TRUE);						// フルスクリーンにしない
-	SetGraphMode(1280, 720, 32);				// ウィンドウサイズと色ビット数の指定
-	SetWindowSizeExtendRate(1.0);				// 実際に表示するウィンドウサイズに変更
-	SetUseCharCodeFormat(DX_CHARCODEFORMAT_UTF8);
+	SetOutApplicationLogValidFlag(FALSE);			// ログを出力しない
+	ChangeWindowMode(TRUE);							// フルスクリーンにしない
+	SetGraphMode(1280, 720, 32);					// ウィンドウサイズと色ビット数の指定
+	SetWindowSizeExtendRate(1.0);					// 実際に表示するウィンドウサイズに変更
 
 	/* 初期化 */
 	if (DxLib_Init() == -1) {
@@ -105,16 +103,15 @@ namespace Game {
 	void MakeHandles() {
 		// フォント作成
 		SetFontCharCodeFormat(DX_CHARCODEFORMAT_UTF8);
-		font1 = CreateFontToHandle(reinterpret_cast<const TCHAR*>(u8"游明朝"), 24, -1, DX_FONTTYPE_ANTIALIASING_16X16, DX_CHARCODEFORMAT_UTF8);
-		font2 = CreateFontToHandle(reinterpret_cast<const TCHAR*>(u8"游明朝"), 18, -1, DX_FONTTYPE_ANTIALIASING_16X16, DX_CHARCODEFORMAT_UTF8);
-		font3 = CreateFontToHandle(reinterpret_cast<const TCHAR*>(u8"游明朝"), 20, -1, DX_FONTTYPE_ANTIALIASING_16X16, DX_CHARCODEFORMAT_UTF8);
-		font4 = CreateFontToHandle(reinterpret_cast<const TCHAR*>(u8"游明朝"), 48, -1, DX_FONTTYPE_ANTIALIASING_16X16, DX_CHARCODEFORMAT_UTF8);
-		font5 = CreateFontToHandle(reinterpret_cast<const TCHAR*>(u8"游明朝"), 12, -1, DX_FONTTYPE_ANTIALIASING_16X16, DX_CHARCODEFORMAT_UTF8);
-		font6 = CreateFontToHandle(reinterpret_cast<const TCHAR*>(u8"游明朝"), 30, -1, DX_FONTTYPE_ANTIALIASING_16X16, DX_CHARCODEFORMAT_UTF8);
+		font1 = CreateFontToHandle((const char*)u8"游明朝", 24, -1, DX_FONTTYPE_ANTIALIASING_16X16, DX_CHARCODEFORMAT_UTF8);
+		font2 = CreateFontToHandle((const char*)u8"游明朝", 18, -1, DX_FONTTYPE_ANTIALIASING_16X16, DX_CHARCODEFORMAT_UTF8);
+		font3 = CreateFontToHandle((const char*)u8"游明朝", 20, -1, DX_FONTTYPE_ANTIALIASING_16X16, DX_CHARCODEFORMAT_UTF8);
+		font4 = CreateFontToHandle((const char*)u8"游明朝", 48, -1, DX_FONTTYPE_ANTIALIASING_16X16, DX_CHARCODEFORMAT_UTF8);
+		font5 = CreateFontToHandle((const char*)u8"游明朝", 12, -1, DX_FONTTYPE_ANTIALIASING_16X16, DX_CHARCODEFORMAT_UTF8);
+		font6 = CreateFontToHandle((const char*)u8"游明朝", 30, -1, DX_FONTTYPE_ANTIALIASING_16X16, DX_CHARCODEFORMAT_UTF8);
 
 		// ダイアログボックス画像読み込み
-		//int gh_tmp = LoadGraph(reinterpret_cast<const TCHAR*>(u8"data/picture/[自作]dialog.png"));
-		Dialog(LoadGraph(reinterpret_cast<const TCHAR*>(u8"data/picture/[自作]dialog.png")));
+		Dialog(LoadGraph((const char*)u8"data/picture/[自作]dialog.png"));
 	}
 
 	void DeleteHandles() {
@@ -158,27 +155,22 @@ namespace Game {
 		if (js_cfg["se"].is_object()) {
 			if (js_cfg["se"]["cursor"].is_string()) {
 				tmp = js_cfg["se"]["cursor"];
-				//sh_cursor = LoadSoundMem(utf8_to_ansi(js_cfg["se"]["cursor"]).c_str());
 				sh_cursor = LoadSoundMem(tmp.c_str());
 			}
 			if (js_cfg["se"]["decide"].is_string()) {
 				tmp = js_cfg["se"]["decide"];
-				//sh_decide = LoadSoundMem(utf8_to_ansi(js_cfg["se"]["decide"]).c_str());
 				sh_decide = LoadSoundMem(tmp.c_str());
 			}
 			if (js_cfg["se"]["cancel"].is_string()) {
 				tmp = js_cfg["se"]["cancel"];
-				//sh_cancel = LoadSoundMem(utf8_to_ansi(js_cfg["se"]["cancel"]).c_str());
 				sh_cancel = LoadSoundMem(tmp.c_str());
 			}
 			if (js_cfg["se"]["success"].is_string()) {
 				tmp = js_cfg["se"]["success"];
-				//sh_success = LoadSoundMem(utf8_to_ansi(js_cfg["se"]["success"]).c_str());
 				sh_success = LoadSoundMem(tmp.c_str());
 			}
 			if (js_cfg["se"]["fail"].is_string()) {
 				tmp = js_cfg["se"]["fail"];
-				//sh_fail = LoadSoundMem(utf8_to_ansi(js_cfg["se"]["fail"]).c_str());
 				sh_fail = LoadSoundMem(tmp.c_str());
 			}
 		}
@@ -206,13 +198,11 @@ namespace Game {
 		if (js_cfg["title"].is_object()) {
 			if (js_cfg["title"]["back"].is_array()) {
 				if (js_cfg["title"]["back"][0].is_string()) {
-					//strBack = utf8_to_ansi(js_cfg["title"]["back"][0]);
 					strBack =js_cfg["title"]["back"][0];
 				}
 			}
 			if (js_cfg["title"]["bgm"].is_array()) {
 				if (js_cfg["title"]["bgm"][0].is_string()) {
-					//strBgm = utf8_to_ansi(js_cfg["title"]["bgm"][0]);
 					strBgm = js_cfg["title"]["bgm"][0];
 				}
 				if (js_cfg["title"]["bgm"][1].is_number()) {

--- a/source/Menu.cpp
+++ b/source/Menu.cpp
@@ -32,10 +32,10 @@ namespace Game {
 		// セーブファイル作成
 		try {
 			js_saveFile[i] = json::object();
-			js_saveFile[i]["header"]["soft"]["name"] = ansi_to_utf8(SOFT_NAME);
-			js_saveFile[i]["header"]["soft"]["ver"] = ansi_to_utf8(SOFT_VER);
-			js_saveFile[i]["header"]["game"]["name"] = ansi_to_utf8(strGameName);
-			js_saveFile[i]["header"]["game"]["ver"] = ansi_to_utf8(strGameVersion);
+			js_saveFile[i]["header"]["soft"]["name"] = SOFT_NAME;
+			js_saveFile[i]["header"]["soft"]["ver"] = SOFT_VER;
+			js_saveFile[i]["header"]["game"]["name"] = strGameName;
+			js_saveFile[i]["header"]["game"]["ver"] = strGameVersion;
 			js_saveFile[i]["save"]["time"] = saveData[i].saveTime;
 			js_saveFile[i]["save"]["count"] = saveData[i].saveCount;
 			js_saveFile[i]["save"]["data"]["index_place"] = saveData[i].index_place;

--- a/source/Menu.cpp
+++ b/source/Menu.cpp
@@ -97,11 +97,11 @@ namespace Game {
 		opt = button1.Main(onTitle);
 
 		// 文字描画
-		DrawStringToHandle(560, 160, "～セーブ～", 0xFFFFFF, font3);
-		DrawStringToHandle(160, 240, "・セーブ１", 0xFFFFFF, font3);
-		DrawStringToHandle(160, 340, "・セーブ２", 0xFFFFFF, font3);
-		DrawStringToHandle(160, 440, "・セーブ３", 0xFFFFFF, font3);
-		DrawStringToHandle(910, 580, "タイトルに戻る", 0xFFFFFF, font3);
+		DrawStringToHandle(560, 160, (const char*)u8"～セーブ～", 0xFFFFFF, font3);
+		DrawStringToHandle(160, 240, (const char*)u8"・セーブ１", 0xFFFFFF, font3);
+		DrawStringToHandle(160, 340, (const char*)u8"・セーブ２", 0xFFFFFF, font3);
+		DrawStringToHandle(160, 440, (const char*)u8"・セーブ３", 0xFFFFFF, font3);
+		DrawStringToHandle(910, 580, (const char*)u8"タイトルに戻る", 0xFFFFFF, font3);
 
 		DrawLine(160, 550, 1120, 550, 0xFFFFFF);
 
@@ -122,7 +122,7 @@ namespace Game {
 					sprintf_s(min2, 3, "%d", min);
 				}
 
-				DrawFormatStringToHandle(160, 280 + 100 * i, 0xFFFFFF, font3, "　最終セーブ：%d年%d月%d日　%d時%s分　セーブ回数：%d回",
+				DrawFormatStringToHandle(160, 280 + 100 * i, 0xFFFFFF, font3, (const char*)u8"　最終セーブ：%d年%d月%d日　%d時%s分　セーブ回数：%d回",
 					year, month, day, hour, min2, saveData[i].saveCount);
 			}
 		}
@@ -160,9 +160,9 @@ namespace Game {
 				break;
 			}
 
-			DrawStringToHandle(475, 345, "タイトルに戻りますか？", 0x000000, font3);
-			DrawStringToHandle(565, 410, "はい", yes, font3);
-			DrawStringToHandle(655, 410, "いいえ", no, font3);
+			DrawStringToHandle(475, 345, (const char*)u8"タイトルに戻りますか？", 0x000000, font3);
+			DrawStringToHandle(565, 410, (const char*)u8"はい", yes, font3);
+			DrawStringToHandle(655, 410, (const char*)u8"いいえ", no, font3);
 		}
 		else {
 			switch (opt)

--- a/source/Menu.h
+++ b/source/Menu.h
@@ -4,7 +4,6 @@
 #include <direct.h>
 #include <fstream>
 #include "nlohmann/json.hpp"
-//#include "javacommons/strconv.h"
 #include "Global.h"
 #include "Button.h"
 

--- a/source/Menu.h
+++ b/source/Menu.h
@@ -4,7 +4,7 @@
 #include <direct.h>
 #include <fstream>
 #include "nlohmann/json.hpp"
-#include "javacommons/strconv.h"
+//#include "javacommons/strconv.h"
 #include "Global.h"
 #include "Button.h"
 

--- a/source/Place.cpp
+++ b/source/Place.cpp
@@ -76,7 +76,6 @@ namespace Game {
 
 			if (js["back"][0].is_string()) {
 				string str = js["back"][0];
-				//str = utf8_to_ansi(str);
 				gh_back = LoadGraph(str.c_str());
 				if (gh_back == -1) {
 					ErrorLog(ER_IMG_LOAD, str);
@@ -100,7 +99,6 @@ namespace Game {
 
 			if (js["bgm"][0].is_string()) {
 				string str = js["bgm"][0];
-				//str = utf8_to_ansi(str);
 				sh_bgm = LoadSoundMem(str.c_str());
 			}
 			if (js["bgm"][1].is_boolean()) {
@@ -360,11 +358,9 @@ namespace Game {
 			string content = "";
 			if (js["event"][index_event]["content"][index_factor]["dialog"][0].is_string()) {
 				speaker = js["event"][index_event]["content"][index_factor]["dialog"][0];
-				//speaker = utf8_to_ansi(speaker);
 			}
 			if (js["event"][index_event]["content"][index_factor]["dialog"][1].is_string()) {
 				content = js["event"][index_event]["content"][index_factor]["dialog"][1];
-				//content = utf8_to_ansi(content);
 			}
 			dialog.Set(speaker, content);
 			useDlg = true;
@@ -374,7 +370,6 @@ namespace Game {
 		if (js["event"][index_event]["content"][index_factor]["choice"].is_object()) {
 			if (js["event"][index_event]["content"][index_factor]["choice"]["text"].is_string()) {
 				string str = js["event"][index_event]["content"][index_factor]["choice"]["text"];
-				//dialog.Set("", utf8_to_ansi(str));
 				dialog.Set("", str);
 			}
 			if (js["event"][index_event]["content"][index_factor]["choice"]["option"].is_array()) {
@@ -383,8 +378,7 @@ namespace Game {
 				for (int i = 0; i < n; ++i) {
 					if (js["event"][index_event]["content"][index_factor]["choice"]["option"][i].is_array()
 						&& js["event"][index_event]["content"][index_factor]["choice"]["option"][i][0].is_string()) {
-						string str = js["event"][index_event]["content"][index_factor]["choice"]["option"][i][0];
-						//vstr[i] = utf8_to_ansi(str);
+						vstr[i] = js["event"][index_event]["content"][index_factor]["choice"]["option"][i][0];
 					}
 				}
 				choice.Set(vstr);

--- a/source/Place.cpp
+++ b/source/Place.cpp
@@ -76,7 +76,7 @@ namespace Game {
 
 			if (js["back"][0].is_string()) {
 				string str = js["back"][0];
-				str = utf8_to_ansi(str);
+				//str = utf8_to_ansi(str);
 				gh_back = LoadGraph(str.c_str());
 				if (gh_back == -1) {
 					ErrorLog(ER_IMG_LOAD, str);
@@ -100,7 +100,7 @@ namespace Game {
 
 			if (js["bgm"][0].is_string()) {
 				string str = js["bgm"][0];
-				str = utf8_to_ansi(str);
+				//str = utf8_to_ansi(str);
 				sh_bgm = LoadSoundMem(str.c_str());
 			}
 			if (js["bgm"][1].is_boolean()) {
@@ -360,11 +360,11 @@ namespace Game {
 			string content = "";
 			if (js["event"][index_event]["content"][index_factor]["dialog"][0].is_string()) {
 				speaker = js["event"][index_event]["content"][index_factor]["dialog"][0];
-				speaker = utf8_to_ansi(speaker);
+				//speaker = utf8_to_ansi(speaker);
 			}
 			if (js["event"][index_event]["content"][index_factor]["dialog"][1].is_string()) {
 				content = js["event"][index_event]["content"][index_factor]["dialog"][1];
-				content = utf8_to_ansi(content);
+				//content = utf8_to_ansi(content);
 			}
 			dialog.Set(speaker, content);
 			useDlg = true;
@@ -374,7 +374,8 @@ namespace Game {
 		if (js["event"][index_event]["content"][index_factor]["choice"].is_object()) {
 			if (js["event"][index_event]["content"][index_factor]["choice"]["text"].is_string()) {
 				string str = js["event"][index_event]["content"][index_factor]["choice"]["text"];
-				dialog.Set("", utf8_to_ansi(str));
+				//dialog.Set("", utf8_to_ansi(str));
+				dialog.Set("", str);
 			}
 			if (js["event"][index_event]["content"][index_factor]["choice"]["option"].is_array()) {
 				int n = static_cast<int>(js["event"][index_event]["content"][index_factor]["choice"]["option"].size());
@@ -383,7 +384,7 @@ namespace Game {
 					if (js["event"][index_event]["content"][index_factor]["choice"]["option"][i].is_array()
 						&& js["event"][index_event]["content"][index_factor]["choice"]["option"][i][0].is_string()) {
 						string str = js["event"][index_event]["content"][index_factor]["choice"]["option"][i][0];
-						vstr[i] = utf8_to_ansi(str);
+						//vstr[i] = utf8_to_ansi(str);
 					}
 				}
 				choice.Set(vstr);

--- a/source/Place.h
+++ b/source/Place.h
@@ -4,7 +4,6 @@
 #include <string_view>
 #include <fstream>
 #include "nlohmann/json.hpp"
-//#include "javacommons/strconv.h"
 #include "Global.h"
 #include "BackImage.h"
 #include "Dialog.h"

--- a/source/Place.h
+++ b/source/Place.h
@@ -4,7 +4,7 @@
 #include <string_view>
 #include <fstream>
 #include "nlohmann/json.hpp"
-#include "javacommons/strconv.h"
+//#include "javacommons/strconv.h"
 #include "Global.h"
 #include "BackImage.h"
 #include "Dialog.h"

--- a/source/Title.cpp
+++ b/source/Title.cpp
@@ -19,8 +19,8 @@ namespace Game {
 
 		showVerFlag = showVer;
 
-		width_hajime = GetDrawStringWidthToHandle("‚Í‚¶‚ß‚©‚ç", static_cast<int>(strlen("‚Í‚¶‚ß‚©‚ç")), font6);
-		width_tuduki = GetDrawStringWidthToHandle("‚Â‚Ã‚«‚©‚ç", static_cast<int>(strlen("‚Â‚Ã‚«‚©‚ç")), font6);
+		width_hajime = GetDrawStringWidthToHandle(reinterpret_cast<const TCHAR*>(u8"‚Í‚¶‚ß‚©‚ç"), static_cast<int>(strlen(reinterpret_cast<const TCHAR*>(u8"‚Í‚¶‚ß‚©‚ç"))), font6);
+		width_tuduki = GetDrawStringWidthToHandle(reinterpret_cast<const TCHAR*>(u8"‚Â‚Ã‚«‚©‚ç"), static_cast<int>(strlen(reinterpret_cast<const TCHAR*>(u8"‚Â‚Ã‚«‚©‚ç"))), font6);
 
 		button_title = Button(2);
 		button_title.SetGroup(1, 0);
@@ -122,8 +122,8 @@ namespace Game {
 			DrawBoxAA((WIDTH - 250) / 2, 500, (WIDTH + 250) / 2, 660, 0xAAAAAA, FALSE, 2.f);
 			SetDrawBlendMode(DX_BLENDMODE_NOBLEND, 0);
 			button_title.Main(false);
-			DrawStringToHandle((WIDTH - width_hajime) / 2, 528, "‚Í‚¶‚ß‚©‚ç", 0x000000, font6);
-			DrawStringToHandle((WIDTH - width_tuduki) / 2, 605, "‚Â‚Ã‚«‚©‚ç", 0x000000, font6);
+			DrawStringToHandle((WIDTH - width_hajime) / 2, 528, reinterpret_cast<const TCHAR*>(u8"‚Í‚¶‚ß‚©‚ç"), 0x000000, font6);
+			DrawStringToHandle((WIDTH - width_tuduki) / 2, 605, reinterpret_cast<const TCHAR*>(u8"‚Â‚Ã‚«‚©‚ç"), 0x000000, font6);
 
 			// ƒo[ƒWƒ‡ƒ“î•ñ
 			if (showVerFlag) {

--- a/source/Title.cpp
+++ b/source/Title.cpp
@@ -19,8 +19,8 @@ namespace Game {
 
 		showVerFlag = showVer;
 
-		width_hajime = GetDrawStringWidthToHandle(reinterpret_cast<const TCHAR*>(u8"はじめから"), static_cast<int>(strlen(reinterpret_cast<const TCHAR*>(u8"はじめから"))), font6);
-		width_tuduki = GetDrawStringWidthToHandle(reinterpret_cast<const TCHAR*>(u8"つづきから"), static_cast<int>(strlen(reinterpret_cast<const TCHAR*>(u8"つづきから"))), font6);
+		width_hajime = GetDrawStringWidthToHandle((const char*)u8"はじめから", static_cast<int>(strlen((const char*)u8"はじめから")), font6);
+		width_tuduki = GetDrawStringWidthToHandle((const char*)u8"つづきから", static_cast<int>(strlen((const char*)u8"つづきから")), font6);
 
 		button_title = Button(2);
 		button_title.SetGroup(1, 0);
@@ -32,7 +32,7 @@ namespace Game {
 		button_load.SetButton(0, 160, 230, 960, 85);
 		button_load.SetButton(1, 160, 330, 960, 85);
 		button_load.SetButton(2, 160, 430, 960, 85);
-		button_load.SetButton(3, 905, 570, GetDrawStringWidthToHandle("タイトルに戻る", static_cast<int>(strlen("タイトルに戻る")), font3) + 10, 40);
+		button_load.SetButton(3, 905, 570, GetDrawStringWidthToHandle((const char*)u8"タイトルに戻る", static_cast<int>(strlen((const char*)u8"タイトルに戻る")), font3) + 10, 40);
 	}
 
 	int Title::Main() {
@@ -122,8 +122,8 @@ namespace Game {
 			DrawBoxAA((WIDTH - 250) / 2, 500, (WIDTH + 250) / 2, 660, 0xAAAAAA, FALSE, 2.f);
 			SetDrawBlendMode(DX_BLENDMODE_NOBLEND, 0);
 			button_title.Main(false);
-			DrawStringToHandle((WIDTH - width_hajime) / 2, 528, reinterpret_cast<const TCHAR*>(u8"はじめから"), 0x000000, font6);
-			DrawStringToHandle((WIDTH - width_tuduki) / 2, 605, reinterpret_cast<const TCHAR*>(u8"つづきから"), 0x000000, font6);
+			DrawStringToHandle((WIDTH - width_hajime) / 2, 528, (const char*)u8"はじめから", 0x000000, font6);
+			DrawStringToHandle((WIDTH - width_tuduki) / 2, 605, (const char*)u8"つづきから", 0x000000, font6);
 
 			// バージョン情報
 			if (showVerFlag) {
@@ -187,12 +187,12 @@ namespace Game {
 			}
 
 			// 文字描画
-			DrawStringToHandle(430, 160, "～ロードするファイルを選択～", 0x000000, font3);
-			DrawStringToHandle(160, 240, "・セーブ１", 0x000000, font3);
-			DrawStringToHandle(160, 340, "・セーブ２", 0x000000, font3);
-			DrawStringToHandle(160, 440, "・セーブ３", 0x000000, font3);
+			DrawStringToHandle(430, 160, (const char*)u8"～ロードするファイルを選択～", 0x000000, font3);
+			DrawStringToHandle(160, 240, (const char*)u8"・セーブ１", 0x000000, font3);
+			DrawStringToHandle(160, 340, (const char*)u8"・セーブ２", 0x000000, font3);
+			DrawStringToHandle(160, 440, (const char*)u8"・セーブ３", 0x000000, font3);
 			DrawLine(160, 550, 1120, 550, 0x000000);
-			DrawStringToHandle(910, 580, "タイトルに戻る", 0x000000, font3);
+			DrawStringToHandle(910, 580, (const char*)u8"タイトルに戻る", 0x000000, font3);
 
 			for (int i = 0; i < 3; ++i) {
 				if (saveData[i].saveCount != 0) {
@@ -211,7 +211,7 @@ namespace Game {
 					else {
 						strMin = std::to_string(min);
 					}
-					DrawFormatStringToHandle(160, 280 + 100 * i, 0x000000, font3, "　最終セーブ：%d年%d月%d日　%d時%s分　セーブ回数：%d回", year, month, day, hour, strMin.c_str(), saveData[i].saveCount);
+					DrawFormatStringToHandle(160, 280 + 100 * i, 0x000000, font3, (const char*)u8"　最終セーブ：%d年%d月%d日　%d時%s分　セーブ回数：%d回", year, month, day, hour, strMin.c_str(), saveData[i].saveCount);
 				}
 			}
 			break;
@@ -225,8 +225,8 @@ namespace Game {
 			DrawBoxAA((WIDTH - 250) / 2, 500, (WIDTH + 250) / 2, 660, 0xAAAAAA, FALSE, 2.f);
 			SetDrawBlendMode(DX_BLENDMODE_NOBLEND, 0);
 			button_title.Main(true);
-			DrawStringToHandle((WIDTH - width_hajime) / 2, 528, "はじめから", 0x000000, font6);
-			DrawStringToHandle((WIDTH - width_tuduki) / 2, 605, "つづきから", 0x000000, font6);
+			DrawStringToHandle((WIDTH - width_hajime) / 2, 528, (const char*)u8"はじめから", 0x000000, font6);
+			DrawStringToHandle((WIDTH - width_tuduki) / 2, 605, (const char*)u8"つづきから", 0x000000, font6);
 
 			// バージョン情報
 			if (showVerFlag) {
@@ -260,12 +260,12 @@ namespace Game {
 			button_load.Main(true);
 
 			// 文字描画
-			DrawStringToHandle(430, 160, "～ロードするファイルを選択～", 0x000000, font3);
-			DrawStringToHandle(160, 240, "・セーブ１", 0x000000, font3);
-			DrawStringToHandle(160, 340, "・セーブ２", 0x000000, font3);
-			DrawStringToHandle(160, 440, "・セーブ３", 0x000000, font3);
+			DrawStringToHandle(430, 160, (const char*)u8"～ロードするファイルを選択～", 0x000000, font3);
+			DrawStringToHandle(160, 240, (const char*)u8"・セーブ１", 0x000000, font3);
+			DrawStringToHandle(160, 340, (const char*)u8"・セーブ２", 0x000000, font3);
+			DrawStringToHandle(160, 440, (const char*)u8"・セーブ３", 0x000000, font3);
 			DrawLine(160, 550, 1120, 550, 0x000000);
-			DrawStringToHandle(910, 580, "タイトルに戻る", 0x000000, font3);
+			DrawStringToHandle(910, 580, (const char*)u8"タイトルに戻る", 0x000000, font3);
 			for (int i = 0; i < 3; ++i) {
 				if (saveData[i].saveCount != 0) {
 					struct tm local;
@@ -283,7 +283,7 @@ namespace Game {
 					else {
 						strMin = std::to_string(min);
 					}
-					DrawFormatStringToHandle(160, 280 + 100 * i, 0x000000, font3, "　最終セーブ：%d年%d月%d日　%d時%s分　セーブ回数：%d回", year, month, day, hour, strMin.c_str(), saveData[i].saveCount);
+					DrawFormatStringToHandle(160, 280 + 100 * i, 0x000000, font3, (const char*)u8"　最終セーブ：%d年%d月%d日　%d時%s分　セーブ回数：%d回", year, month, day, hour, strMin.c_str(), saveData[i].saveCount);
 				}
 			}
 
@@ -306,7 +306,7 @@ namespace Game {
 		}
 
 		fcounter++;
-		image.Main();
+		//image.Main();
 
 		return res;
 	}

--- a/source/Utilities.cpp
+++ b/source/Utilities.cpp
@@ -1,0 +1,89 @@
+#include "Utilities.h"
+
+namespace Game {
+	size_t strcount_utf8(const char* str) {
+		size_t zStrCount = 0;
+		size_t zStrLen = std::strlen(str);
+		for (size_t i = 0; i < zStrLen; ++i) {
+			// マルチバイト文字の2バイト目以降
+			if (static_cast<unsigned char>(str[i]) >= 0x80 && static_cast<unsigned char>(str[i]) <= 0xBF) {
+				continue;
+			}
+			// Xバイト文字の1文字目
+			else {
+				// 描画指定コマンドを除外
+				if (str[i] == u8'\\' && i + 3 < zStrLen && str[i + 3] == u8'\\') {
+					if (str[i + 1] == u8'c' || str[i + 1] == u8's') {
+						if (str[i + 2] >= u8'0' && str[i + 2] <= u8'9') {
+							i += 3;
+							continue;
+						}
+					}
+				}
+				// 文字数を+1
+				++zStrCount;
+			}
+		}
+		return zStrCount;
+	}
+
+	string strextract_utf8(const char* str, size_t nCount) {
+		size_t zStrCount = 0;
+		size_t zStrLen = std::strlen(str);
+		string strRes = "";
+		unsigned char c;
+		for (size_t i = 0; i < zStrLen; ++i) {
+			c = static_cast<unsigned char>(str[i]);
+			if (zStrCount >= nCount) {
+				break;
+			}
+			// 1バイト文字の処理
+			if (c >= 0x00 && c <= 0x7F) {
+				// 描画指定コマンドは何もせずに、そのまま格納
+				if (str[i] == u8'\\' && i + 3 < zStrLen && str[i + 3] == u8'\\') {
+					if (str[i + 1] == u8'c' || str[i + 1] == u8's') {
+						if (str[i + 2] >= u8'0' && str[i + 2] <= u8'9') {
+							strRes += str[i];
+							strRes += str[i + 1];
+							strRes += str[i + 2];
+							strRes += str[i + 3];
+							i += 3;
+						}
+					}
+				}
+				else if (str[i] == u8'\n') {
+					strRes += str[i];
+				}
+				else {
+					strRes += str[i];
+					zStrCount++;
+				}
+			}
+			// 2バイト文字の処理
+			else if (c >= 0xC0 && c <= 0xDF) {
+				strRes += str[i];
+				strRes += str[i + 1];
+				zStrCount++;
+				i++;
+			}
+			// 3バイト文字の処理
+			else if (c >= 0xE0 && c <= 0xEF) {
+				strRes += str[i];
+				strRes += str[i + 1];
+				strRes += str[i + 2];
+				zStrCount++;
+				i += 2;
+			}
+			// 4バイト文字の処理;
+			else if (c >= 0xF0 && c <= 0xF7) {
+				strRes += str[i];
+				strRes += str[i + 1];
+				strRes += str[i + 2];
+				strRes += str[i + 3];
+				zStrCount++;
+				i += 3;
+			}
+		}
+		return strRes;
+	}
+}

--- a/source/Utilities.h
+++ b/source/Utilities.h
@@ -1,0 +1,11 @@
+#pragma once
+#include <string>
+
+using std::string;
+using std::string_view;
+
+namespace Game {
+	size_t strcount_utf8(const char* str);
+
+	string strextract_utf8(const char* str, size_t nCount);
+}


### PR DESCRIPTION
 - DxLibの関数に渡す文字列引数の文字コードをShift-JISからUTF-8へ変更
 - JSONファイルから読み込んだ文字列の ansi への変換が不要に
 - `strconv.h`はプロジェクトから除外してよい